### PR TITLE
OD-411 : Change private office resource view message

### DIFF
--- a/ckanext/officedocs/plugin.py
+++ b/ckanext/officedocs/plugin.py
@@ -24,8 +24,10 @@ class OfficeDocsPlugin(plugins.SingletonPlugin):
     def setup_template_variables(self, context, data_dict):
         from urllib import quote_plus
         url = quote_plus(data_dict["resource"]["url"])
+        private_visibility = data_dict["package"]["private"]
         return {
-            "resource_url": url
+            "resource_url": url,
+            "visibility": private_visibility
         }
 
     def can_view(self, data_dict):

--- a/ckanext/officedocs/plugin.py
+++ b/ckanext/officedocs/plugin.py
@@ -24,10 +24,10 @@ class OfficeDocsPlugin(plugins.SingletonPlugin):
     def setup_template_variables(self, context, data_dict):
         from urllib import quote_plus
         url = quote_plus(data_dict["resource"]["url"])
-        private_visibility = data_dict["package"]["private"]
+        private_package = data_dict["package"]["private"]
         return {
             "resource_url": url,
-            "visibility": private_visibility
+            "private_package": private_package
         }
 
     def can_view(self, data_dict):

--- a/ckanext/officedocs/templates/officedocs/preview.html
+++ b/ckanext/officedocs/templates/officedocs/preview.html
@@ -1,3 +1,6 @@
+{% if visibility %}
+<div>This resource view will render once the dataset is made public. Microsoft Office preview is unable to access and display private resources.</div>
+{% else %}
 <button id="fullscreeniframe" class="btn" style="position:absolute; right:5px; top:20px">Fullscreen</button>
 <iframe id="cvframe" src="//view.officeapps.live.com/op/view.aspx?src={{resource_url}}" frameborder="0" allowfullscreen="" width="100%" height="400px"></iframe>
 <script>
@@ -41,3 +44,4 @@
         }, false);
     })(this, this.document);
 </script>
+{% endif %}

--- a/ckanext/officedocs/templates/officedocs/preview.html
+++ b/ckanext/officedocs/templates/officedocs/preview.html
@@ -1,4 +1,4 @@
-{% if visibility %}
+{% if private_package %}
 <div>This resource view will render once the dataset is made public. Microsoft Office preview is unable to access and display private resources.</div>
 {% else %}
 <button id="fullscreeniframe" class="btn" style="position:absolute; right:5px; top:20px">Fullscreen</button>

--- a/ckanext/officedocs/templates/officedocs/preview.html
+++ b/ckanext/officedocs/templates/officedocs/preview.html
@@ -1,5 +1,5 @@
 {% if private_package %}
-<div>This resource view will render once the dataset is made public. Microsoft Office preview is unable to access and display private resources.</div>
+<div style="text-align:center;">This resource view will render once the dataset is made public. Microsoft Office preview is unable to access and display private resources.</div>
 {% else %}
 <button id="fullscreeniframe" class="btn" style="position:absolute; right:5px; top:20px">Fullscreen</button>
 <iframe id="cvframe" src="//view.officeapps.live.com/op/view.aspx?src={{resource_url}}" frameborder="0" allowfullscreen="" width="100%" height="400px"></iframe>


### PR DESCRIPTION
For private datasets the Office resource view should give a message that it will only view-able for Pubilc datasets

**Testing:**
1) Select a dataset which have visibility private
2) Select the resource underneath
3) Select the office view
4) User will get the "This resource view will render once the dataset is made public. Microsoft Office preview is unable to access and display private resources."